### PR TITLE
Update Example.vue

### DIFF
--- a/example/Example.vue
+++ b/example/Example.vue
@@ -22,12 +22,12 @@
       :is-fold="props.isFold"
       :expand-type="props.expandType"
       :selection-type="props.selectionType">
-      <template slot="$expand" scope="scope">
+      <template slot="$expand" slot-scope="scope">
         {{ `My name is ${scope.row.name},
            this rowIndex is ${scope.rowIndex}.`
          }}
       </template>
-      <template slot="likes" scope="scope">
+      <template slot="likes" slot-scope="scope">
         {{ scope.row.likes.join(',') }}
       </template>
     </zk-table>


### PR DESCRIPTION
update `scope` attribute to `slot-scope`. 

`scope` attribute has been deprecated and updated with `slot-scope` since **version 2.5**